### PR TITLE
Type consistent return in function get_native_model_name

### DIFF
--- a/suit/templatetags/suit_menu.py
+++ b/suit/templatetags/suit_menu.py
@@ -46,7 +46,7 @@ def get_menu(context, request):
     else:
         try:
             template_response = get_admin_site(context.current_app).index(request)
-        # Django 1.10 removed the current_app parameter for some classes and functions. 
+        # Django 1.10 removed the current_app parameter for some classes and functions.
         # Check the release notes.
         except AttributeError:
             template_response = get_admin_site(context.request.resolver_match.namespace).index(request)
@@ -353,7 +353,7 @@ class Menu(object):
         }
 
     def get_native_model_url(self, model):
-        return model.get('admin_url') or model.get('add_url', '')
+        return model.get('admin_url','') or model.get('add_url', '')
 
     def process_model(self, model, app_name):
         if 'model' in model:


### PR DESCRIPTION
When the function `get_native_model_name` returns a NoneType, there will be an error `'NoneType' object has no attribute 'rstrip'` because of this line:
`url_parts = self.get_native_model_url(model).rstrip('/').split('/')`

This can be prevented by ensuring only a String is returned.